### PR TITLE
Transparent Transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1737,6 +1737,7 @@ dependencies = [
 [[package]]
 name = "neptune-cash"
 version = "0.3.0"
+source = "git+https://github.com/Neptune-Crypto/neptune-core.git?branch=asz%2Ftransparent-transactions#cece8dab9db0334b07a2112a9163e3882ab71a55"
 dependencies = [
  "aead",
  "aes-gcm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,6 +169,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
 name = "arraystring"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,6 +183,12 @@ dependencies = [
  "serde",
  "typenum",
 ]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-stream"
@@ -362,10 +374,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
+name = "blake3"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+]
 
 [[package]]
 name = "block-buffer"
@@ -407,21 +447,6 @@ name = "bytesize"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e93abca9e28e0a1b9877922aacb20576e05d4679ffa78c3d6dc22a26a216659"
-
-[[package]]
-name = "cassowary"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
-
-[[package]]
-name = "castaway"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
-dependencies = [
- "rustversion",
-]
 
 [[package]]
 name = "cc"
@@ -495,15 +520,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap_complete"
-version = "4.5.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5abde44486daf70c5be8b8f8f1b66c49f86236edf6fa2abadb4d961c4c6229a"
-dependencies = [
- "clap",
-]
-
-[[package]]
 name = "clap_derive"
 version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,20 +568,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "compact_str"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
-dependencies = [
- "castaway",
- "cfg-if",
- "itoa",
- "rustversion",
- "ryu",
- "static_assertions",
-]
-
-[[package]]
 name = "const_format"
 version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -584,6 +586,12 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "core-foundation"
@@ -643,47 +651,6 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crossterm"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
-dependencies = [
- "bitflags",
- "crossterm_winapi",
- "libc",
- "mio 0.8.11",
- "parking_lot",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
-dependencies = [
- "bitflags",
- "crossterm_winapi",
- "mio 1.0.4",
- "parking_lot",
- "rustix 0.38.44",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm_winapi"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "crypto-common"
@@ -747,6 +714,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive-ex"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bba95f299f6b9cd47f68a847eca2ae9060a2713af532dc35c342065544845407"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "structmeta",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -934,12 +913,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -1146,11 +1119,6 @@ name = "hashbrown"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash",
-]
 
 [[package]]
 name = "heck"
@@ -1448,31 +1416,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
-
-[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "instability"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435d80800b936787d62688c927b6490e887c7ef5ff9ce922c6c6050fca75eb9a"
-dependencies = [
- "darling",
- "indoc",
- "proc-macro2",
- "quote",
- "syn 2.0.104",
 ]
 
 [[package]]
@@ -1503,15 +1452,6 @@ name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -1620,12 +1560,6 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
@@ -1651,15 +1585,6 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
-
-[[package]]
-name = "lru"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
-dependencies = [
- "hashbrown 0.15.4",
-]
 
 [[package]]
 name = "manyhow"
@@ -1767,24 +1692,11 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
-dependencies = [
- "libc",
- "log",
- "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "mio"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
- "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
 ]
@@ -1825,8 +1737,6 @@ dependencies = [
 [[package]]
 name = "neptune-cash"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0420017f9e5e1c2e9d255a9bd4da9a78989fe0d8f9be550560859d2735d0756"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1840,8 +1750,6 @@ dependencies = [
  "bytesize",
  "chrono",
  "clap",
- "clap_complete",
- "crossterm 0.27.0",
  "directories",
  "field_count",
  "futures",
@@ -1856,7 +1764,6 @@ dependencies = [
  "priority-queue",
  "rand 0.9.2",
  "rand_distr",
- "ratatui",
  "rayon",
  "readonly",
  "regex",
@@ -1867,8 +1774,8 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha3",
- "strum 0.27.2",
- "strum_macros 0.27.2",
+ "strum",
+ "strum_macros",
  "sysinfo",
  "systemstat",
  "tarpc",
@@ -1882,7 +1789,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tracing-test",
- "unicode-width 0.1.14",
  "zeroize",
 ]
 
@@ -1891,8 +1797,10 @@ name = "neptune-explorer"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arbitrary",
  "arc-swap",
  "axum",
+ "blake3",
  "boilerplate",
  "chrono",
  "clap",
@@ -1901,10 +1809,14 @@ dependencies = [
  "indexmap 2.10.0",
  "lettre",
  "neptune-cash",
+ "proptest",
+ "proptest-arbitrary-interop",
+ "rand 0.9.2",
  "readonly",
  "serde",
  "serde_json",
  "tarpc",
+ "test-strategy",
  "thiserror 1.0.69",
  "tokio",
  "tower-http",
@@ -2211,12 +2123,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "pbkdf2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2404,6 +2310,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "lazy_static",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax 0.8.5",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "proptest-arbitrary-interop"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1981e49bd2432249da8b0e11e5557099a8e74690d6b94e721f7dc0bb7f3555f"
+dependencies = [
+ "arbitrary",
+ "proptest",
+]
+
+[[package]]
 name = "psm"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2411,6 +2347,12 @@ checksum = "6e944464ec8536cd1beb0bbfd96987eb5e3b72f2ecdafdc5c769a37f1fa2ae1f"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -2525,24 +2467,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "ratatui"
-version = "0.29.0"
+name = "rand_xorshift"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "bitflags",
- "cassowary",
- "compact_str",
- "crossterm 0.28.1",
- "indoc",
- "instability",
- "itertools 0.13.0",
- "lru",
- "paste",
- "strum 0.26.3",
- "unicode-segmentation",
- "unicode-truncate",
- "unicode-width 0.2.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -2670,19 +2600,6 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
@@ -2690,7 +2607,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.9.4",
+ "linux-raw-sys",
  "windows-sys 0.60.2",
 ]
 
@@ -2699,6 +2616,18 @@ name = "rustversion"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -2859,28 +2788,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
-name = "signal-hook-mio"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
-dependencies = [
- "libc",
- "mio 0.8.11",
- "mio 1.0.4",
- "signal-hook",
-]
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2949,12 +2856,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
-name = "strum"
-version = "0.26.3"
+name = "structmeta"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+checksum = "2e1575d8d40908d70f6fd05537266b90ae71b15dbbe7a8b7dffa2b759306d329"
 dependencies = [
- "strum_macros 0.26.4",
+ "proc-macro2",
+ "quote",
+ "structmeta-derive",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "structmeta-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2963,20 +2884,7 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros 0.27.2",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.104",
+ "strum_macros",
 ]
 
 [[package]]
@@ -3116,7 +3024,7 @@ dependencies = [
  "rand 0.9.2",
  "serde",
  "serde_json",
- "strum 0.27.2",
+ "strum",
  "tasm-object-derive",
  "triton-vm",
 ]
@@ -3141,8 +3049,21 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix 1.0.8",
+ "rustix",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "test-strategy"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b12f9683de37f9980e485167ee624bfaa0b6b04da661e98e25ef9c2669bc1b"
+dependencies = [
+ "derive-ex",
+ "proc-macro2",
+ "quote",
+ "structmeta",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3293,7 +3214,7 @@ dependencies = [
  "bytes",
  "io-uring",
  "libc",
- "mio 1.0.4",
+ "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -3514,7 +3435,7 @@ checksum = "973a0422b170667a558ae36e21643ba827e76d2c663607087f0797888f4c59ad"
 dependencies = [
  "arbitrary",
  "itertools 0.14.0",
- "strum 0.27.2",
+ "strum",
  "triton-constraint-circuit",
  "triton-isa",
  "twenty-first",
@@ -3530,7 +3451,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "strum 0.27.2",
+ "strum",
  "syn 2.0.104",
  "triton-air",
  "triton-constraint-circuit",
@@ -3567,7 +3488,7 @@ dependencies = [
  "nom-language",
  "num-traits",
  "serde",
- "strum 0.27.2",
+ "strum",
  "thiserror 2.0.12",
  "twenty-first",
 ]
@@ -3592,7 +3513,7 @@ dependencies = [
  "rand 0.9.2",
  "rayon",
  "serde",
- "strum 0.27.2",
+ "strum",
  "syn 2.0.104",
  "thiserror 2.0.12",
  "triton-air",
@@ -3600,7 +3521,7 @@ dependencies = [
  "triton-constraint-circuit",
  "triton-isa",
  "twenty-first",
- "unicode-width 0.2.0",
+ "unicode-width",
 ]
 
 [[package]]
@@ -3637,6 +3558,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3656,29 +3583,6 @@ checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
-
-[[package]]
-name = "unicode-truncate"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
-dependencies = [
- "itertools 0.13.0",
- "unicode-segmentation",
- "unicode-width 0.1.14",
-]
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -3742,6 +3646,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,17 @@ derive_more = { version = "1.0.0", features = ["display"] }
 # not a direct dep.  workaround for weird "could not resolve" cargo error
 indexmap = "2.7.0"
 
+blake3 = {version = "1.8.2", optional = true}
+rand = {version = "0.9.2", optional = true}
+
+#[dev-dependencies]
+test-strategy = "0.4.3"
+proptest = "1.7.0"
+arbitrary = "1.4.1"
+proptest-arbitrary-interop = "0.1.0"
+
+[patch.crates-io]
+neptune-cash = {path = "../neptune-core/neptune-core/" }
+
+[features]
+mock = ["dep:blake3", "dep:rand"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ arbitrary = "1.4.1"
 proptest-arbitrary-interop = "0.1.0"
 
 [patch.crates-io]
-neptune-cash = {path = "../neptune-core/neptune-core/" }
+neptune-cash = { git = "https://github.com/Neptune-Crypto/neptune-core.git", branch = "asz/transparent-transactions" }
 
 [features]
 mock = ["dep:blake3", "dep:rand"]

--- a/README.md
+++ b/README.md
@@ -34,14 +34,15 @@ not tested or supported.   Please let us know if you get it work.  patches accep
 2. start neptune-explorer
 
 ```
-nohup neptune-explorer 2>&1 > /path/to/logs/neptune-explorer.log &
+nohup neptune-explorer --site-domain testdomain 2>&1 > /path/to/logs/neptune-explorer.log &
 ```
 
 Notes:
 * The block-explorer automatically uses the same network (mainnet, testnet, etc) as the neptune-core instance it is connected to, and the network is displayed in the web interface.
 * If neptune-core RPC server is running on a non-standard port, you can provide it with the `--neptune-rpc-port` flag.
 * neptune-explorer listens for http requests on port 3000 by default.  This can be changed with the `--listen-port` flag.
-* Site name must be specified with the `--site-name` flag.
+* Site name can be specified with the --site-name flag.
+* Site domain *must* be specified with the `--site-domain` flag.
 
 
 ## Connecting via Browser
@@ -52,7 +53,7 @@ Just navigate to http://localhost:3000/
 
 When connected to an out-of-date or unsynced neptune-core node, it might be a good idea to turn on mocking so that whenever a resource is unavailable, a random one is generated and returned. To do this, compile with the feature flag "mock" and make sure that the "MOCK" environment variable is set.
 
-In one command: `MOCK=1 cargo run --features "mock" -- --site-name testname`
+In one command: `MOCK=1 cargo run --features "mock" -- --site-domain testdomain`
 
 ## SSL/TLS, Nginx, etc.
 

--- a/README.md
+++ b/README.md
@@ -41,13 +41,18 @@ Notes:
 * The block-explorer automatically uses the same network (mainnet, testnet, etc) as the neptune-core instance it is connected to, and the network is displayed in the web interface.
 * If neptune-core RPC server is running on a non-standard port, you can provide it with the `--neptune-rpc-port` flag.
 * neptune-explorer listens for http requests on port 3000 by default.  This can be changed with the `--listen-port` flag.
-* Site name can be specified with the `--site-name` flag.
+* Site name must be specified with the `--site-name` flag.
 
 
 ## Connecting via Browser
 
 Just navigate to http://localhost:3000/
 
+## Mocking
+
+When connected to an out-of-date or unsynced neptune-core node, it might be a good idea to turn on mocking so that whenever a resource is unavailable, a random one is generated and returned. To do this, compile with the feature flag "mock" and make sure that the "MOCK" environment variable is set.
+
+In one command: `MOCK=1 cargo run --features "mock" -- --site-name testname`
 
 ## SSL/TLS, Nginx, etc.
 

--- a/src/html/component/header.rs
+++ b/src/html/component/header.rs
@@ -1,7 +1,7 @@
 use crate::model::app_state::AppStateInner;
 use html_escaper::Escape;
 
-#[derive(boilerplate::Boilerplate)]
+#[derive(Debug, Clone, boilerplate::Boilerplate)]
 #[boilerplate(filename = "web/html/components/header.html")]
 pub struct HeaderHtml<'a> {
     pub state: &'a AppStateInner,

--- a/src/html/page/announcement.rs
+++ b/src/html/page/announcement.rs
@@ -4,6 +4,7 @@ use crate::http_util::rpc_method_err;
 use crate::model::announcement_selector::AnnouncementSelector;
 use crate::model::announcement_type::AnnouncementType;
 use crate::model::app_state::AppState;
+use crate::model::transparent_utxo_tuple::TransparentUtxoTuple;
 use axum::extract::rejection::PathRejection;
 use axum::extract::Path;
 use axum::extract::State;
@@ -15,6 +16,8 @@ use neptune_cash::api::export::BlockHeight;
 use neptune_cash::prelude::tasm_lib::prelude::Digest;
 use neptune_cash::prelude::triton_vm::prelude::BFieldCodec;
 use neptune_cash::prelude::twenty_first::tip5::Tip5;
+use neptune_cash::util_types::mutator_set::addition_record::AdditionRecord;
+use std::collections::HashMap;
 use std::sync::Arc;
 use tarpc::context;
 
@@ -32,6 +35,7 @@ pub async fn announcement_page(
         block_hash: Digest,
         block_height: BlockHeight,
         announcement_type: AnnouncementType,
+        addition_record_indices: HashMap<AdditionRecord, Option<u64>>,
     }
 
     let state = &state_rw.load();
@@ -73,6 +77,58 @@ pub async fn announcement_page(
         .clone();
     let announcement_type = AnnouncementType::parse(announcement);
 
+    let mut addition_record_indices = HashMap::<AdditionRecord, Option<u64>>::new();
+    if let AnnouncementType::TransparentTxInfo(tx_info) = announcement_type.clone() {
+        let addition_records = tx_info
+            .outputs
+            .iter()
+            .map(|output| output.addition_record())
+            .collect::<Vec<_>>();
+        addition_record_indices = state.rpc_client.addition_record_indices_for_block(context::current(), state.token(), block_selector, &addition_records).await
+                .map_err(|e| not_found_html_response(state, Some(e.to_string())))?
+                .map_err(rpc_method_err)?
+                .expect(
+                    "block guaranteed to exist because we got here; getting its announcements should work",
+                );
+
+        let mut transparent_utxos_cache = state.transparent_utxos_cache.lock().await;
+
+        for input in &tx_info.inputs {
+            let addition_record = input.addition_record();
+            if let Some(existing_entry) = transparent_utxos_cache
+                .iter_mut()
+                .find(|tu| tu.addition_record() == addition_record)
+            {
+                existing_entry.upgrade_with_transparent_input(input, block_hash);
+            } else {
+                tracing::info!("Adding transparent UTXO (input side) to cache.");
+                transparent_utxos_cache.push(TransparentUtxoTuple::new_from_transparent_input(
+                    input, block_hash,
+                ));
+            }
+        }
+
+        for output in &tx_info.outputs {
+            let addition_record = output.addition_record();
+            if let Some(existing_entry) = transparent_utxos_cache
+                .iter_mut()
+                .find(|tu| tu.addition_record() == addition_record)
+            {
+                existing_entry.upgrade_with_transparent_output(block_hash);
+            } else {
+                tracing::info!("Adding transparent UTXO (output side) to cache.");
+                transparent_utxos_cache.push(TransparentUtxoTuple::new_from_transparent_output(
+                    output,
+                    addition_record_indices
+                        .get(&addition_record)
+                        .cloned()
+                        .unwrap_or(None),
+                    block_hash,
+                ));
+            }
+        }
+    }
+
     let header = HeaderHtml { state };
 
     let utxo_page = AnnouncementHtmlPage {
@@ -82,6 +138,7 @@ pub async fn announcement_page(
         block_height,
         num_announcements,
         announcement_type,
+        addition_record_indices,
     };
     Ok(Html(utxo_page.to_string()))
 }

--- a/src/html/page/mod.rs
+++ b/src/html/page/mod.rs
@@ -1,3 +1,4 @@
+pub mod announcement;
 pub mod block;
 pub mod not_found;
 pub mod redirect_qs_to_path;

--- a/src/html/page/utxo.rs
+++ b/src/html/page/utxo.rs
@@ -2,6 +2,7 @@ use crate::html::component::header::HeaderHtml;
 use crate::html::page::not_found::not_found_html_response;
 use crate::http_util::rpc_method_err;
 use crate::model::app_state::AppState;
+use crate::model::transparent_utxo_tuple::TransparentUtxoTuple;
 use axum::extract::rejection::PathRejection;
 use axum::extract::Path;
 use axum::extract::State;
@@ -9,6 +10,7 @@ use axum::response::Html;
 use axum::response::Response;
 use html_escaper::Escape;
 use html_escaper::Trusted;
+use neptune_cash::api::export::Tip5;
 use neptune_cash::prelude::tasm_lib::prelude::Digest;
 use std::sync::Arc;
 use tarpc::context;
@@ -24,16 +26,18 @@ pub async fn utxo_page(
         header: HeaderHtml<'a>,
         index: u64,
         digest: Digest,
+        transparent_utxo_info: Option<TransparentUtxoTuple>,
     }
 
     let state = &state_rw.load();
+    let cache = state.transparent_utxos_cache.clone();
 
     let Path(index) =
         index_maybe.map_err(|e| not_found_html_response(state, Some(e.to_string())))?;
 
     let digest = match state
         .rpc_client
-        .utxo_digest(context::current(), state.token(), index)
+        .utxo_digest(context::current(), state.token(), index, cache)
         .await
         .map_err(|e| not_found_html_response(state, Some(e.to_string())))?
         .map_err(rpc_method_err)?
@@ -49,10 +53,19 @@ pub async fn utxo_page(
 
     let header = HeaderHtml { state };
 
+    let transparent_utxo_info = state
+        .transparent_utxos_cache
+        .lock()
+        .await
+        .iter()
+        .find(|tu| tu.aocl_leaf_index().is_some_and(|li| li == index))
+        .cloned();
+
     let utxo_page = UtxoHtmlPage {
         index,
         header,
         digest,
+        transparent_utxo_info,
     };
     Ok(Html(utxo_page.to_string()))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use anyhow::Context;
 use axum::routing::get;
 use axum::routing::Router;
 use neptune_explorer::alert_email;
+use neptune_explorer::html::page::announcement::announcement_page;
 use neptune_explorer::html::page::block::block_page;
 use neptune_explorer::html::page::not_found::not_found_html_fallback;
 use neptune_explorer::html::page::redirect_qs_to_path::redirect_query_string_to_path;
@@ -57,6 +58,7 @@ pub fn setup_routes(app_state: AppState) -> Router {
         .route("/", get(root))
         .route("/block/*selector", get(block_page))
         .route("/utxo/:value", get(utxo_page))
+        .route("/announcement/*selector", get(announcement_page))
         // -- Rewrite query-strings to path --
         .route("/rqs", get(redirect_query_string_to_path))
         // -- Static files --

--- a/src/model/announcement_selector.rs
+++ b/src/model/announcement_selector.rs
@@ -1,0 +1,336 @@
+use neptune_cash::api::export::BlockHeight;
+use neptune_cash::models::blockchain::block::block_selector::BlockSelector;
+use neptune_cash::prelude::tasm_lib::prelude::Digest;
+use serde::de::Error;
+use serde::Deserialize;
+use serde::Deserializer;
+use std::fmt::Display;
+use std::str::FromStr;
+
+/// newtype for `BlockSelector` that provides ability to parse `height_or_digest/value`.
+///
+/// This is useful for HTML form(s) that allow user to enter either height or
+/// digest into the same text input field.
+///
+/// In particular it is necessary to support javascript-free website with such
+/// an html form.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AnnouncementSelector {
+    pub block_selector: BlockSelector,
+    pub index: usize,
+}
+
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum AnnouncementSelectorParseError {
+    #[error("too many or too few parts in announcement path")]
+    NumberOfParts,
+    #[error("error parsing index for announcement in tip: {0}")]
+    TipIndex(std::num::ParseIntError),
+    #[error("error parsing index for announcement in genesis block: {0}")]
+    GenesisIndex(std::num::ParseIntError),
+    #[error("error parsing block height: {0}")]
+    BlockHeight(std::num::ParseIntError),
+    #[error("error parsing index for announcement in block {0}: {1}")]
+    HeightIndex(BlockHeight, std::num::ParseIntError),
+    #[error("error parsing digest: {0}")]
+    BlockDigest(neptune_cash::prelude::twenty_first::error::TryFromHexDigestError),
+    #[error("error parsing index for announcement in block {0}: {1}")]
+    DigestIndex(Digest, std::num::ParseIntError),
+    #[error("error parsing block-height-or-digest: {0} / {1}")]
+    HeightNorDigest(
+        std::num::ParseIntError,
+        neptune_cash::prelude::twenty_first::error::TryFromHexDigestError,
+    ),
+    #[error("error parsing index for block-height-or-digest {0}: {1}")]
+    HeightOrDigestIndex(BlockSelector, std::num::ParseIntError),
+    #[error("invalid keyword {0} or {1}")]
+    InvalidKeyword(String, String),
+    #[error("invalid prefix: {0}")]
+    InvalidPrefix(String),
+}
+
+impl FromStr for AnnouncementSelector {
+    type Err = AnnouncementSelectorParseError;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        let parts: Vec<&str> = input.split('/').collect();
+
+        let (block_selector, index) = match parts.as_slice() {
+            ["tip", index] => {
+                let index = index.parse::<u64>().map_err(Self::Err::TipIndex)?;
+                (BlockSelector::Tip, index)
+            }
+            ["genesis", index] => index
+                .parse::<u64>()
+                .map(|i| (BlockSelector::Genesis, i))
+                .map_err(Self::Err::GenesisIndex)?,
+            ["height", number, index] => {
+                let height_as_u64 = number.parse::<u64>().map_err(Self::Err::BlockHeight)?;
+                let block_height = BlockHeight::from(height_as_u64);
+                (
+                    BlockSelector::Height(block_height),
+                    index
+                        .parse()
+                        .map_err(|e| Self::Err::HeightIndex(block_height, e))?,
+                )
+            }
+            ["digest", hash, index] => {
+                let digest = Digest::try_from_hex(hash).map_err(Self::Err::BlockDigest)?;
+                let index = index
+                    .parse::<u64>()
+                    .map_err(|e| Self::Err::DigestIndex(digest, e))?;
+                (BlockSelector::Digest(digest), index)
+            }
+            ["height_or_digest", hod, "index", index] => {
+                let parsed_height = hod.parse::<u64>();
+                let parsed_digest = Digest::try_from_hex(hod);
+
+                let block_selector = match (parsed_height, parsed_digest) {
+                    (Ok(_), Ok(digest)) => {
+                        // unreachable? Not in theory ...
+                        BlockSelector::Digest(digest)
+                    }
+                    (Ok(h), Err(_)) => BlockSelector::Height(BlockHeight::from(h)),
+                    (Err(_), Ok(digest)) => BlockSelector::Digest(digest),
+                    (Err(pie), Err(hde)) => {
+                        return Err(Self::Err::HeightNorDigest(pie, hde));
+                    }
+                };
+
+                let index = index
+                    .parse::<u64>()
+                    .map_err(|e| Self::Err::HeightOrDigestIndex(block_selector, e))?;
+                (block_selector, index)
+            }
+            [prefix, _, keyword, _] => {
+                return Err(Self::Err::InvalidKeyword(
+                    prefix.to_string(),
+                    keyword.to_string(),
+                ))
+            }
+            [prefix, _, _] | [prefix, _] => {
+                return Err(Self::Err::InvalidPrefix(prefix.to_string()))
+            }
+            &[] | &[_] | &[_, _, _, _, _, ..] => return Err(Self::Err::NumberOfParts),
+        };
+
+        Ok(AnnouncementSelector {
+            block_selector,
+            index: index as usize,
+        })
+    }
+}
+
+impl Display for AnnouncementSelector {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.block_selector {
+            BlockSelector::Digest(digest) => write!(f, "digest/{digest:x}/{}", self.index),
+            BlockSelector::Height(block_height) => {
+                write!(f, "height/{}/{}", block_height, self.index)
+            }
+            BlockSelector::Genesis => write!(f, "genesis/{}", self.index),
+            BlockSelector::Tip => write!(f, "tip/{}", self.index),
+        }
+    }
+}
+
+// note: axum uses serde Deserialize for Path elements.
+impl<'de> Deserialize<'de> for AnnouncementSelector {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Self::from_str(&s).map_err(D::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use arbitrary::{Arbitrary, Unstructured};
+    use proptest::string::string_regex;
+    use proptest::{prop_assert, prop_assert_eq};
+    use proptest_arbitrary_interop::arb;
+    use std::str::FromStr;
+    use test_strategy::proptest;
+
+    impl<'a> Arbitrary<'a> for AnnouncementSelector {
+        fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+            // Pick one of the variants randomly
+            let variant = u.int_in_range(0..=3)?;
+
+            let selector = match variant {
+                0 => {
+                    // Digest selector
+                    let digest = Digest::arbitrary(u)?;
+                    let index = u64::arbitrary(u)? as usize;
+                    AnnouncementSelector {
+                        block_selector: BlockSelector::Digest(digest),
+                        index,
+                    }
+                }
+                1 => {
+                    // Height selector
+                    let height_u64 = u64::arbitrary(u)?;
+                    let bh = BlockHeight::from(height_u64);
+                    let index = u64::arbitrary(u)? as usize;
+                    AnnouncementSelector {
+                        block_selector: BlockSelector::Height(bh),
+                        index,
+                    }
+                }
+                2 => {
+                    // Genesis selector
+                    let index = u64::arbitrary(u)? as usize;
+                    AnnouncementSelector {
+                        block_selector: BlockSelector::Genesis,
+                        index,
+                    }
+                }
+                3 => {
+                    // Tip selector
+                    let index = u64::arbitrary(u)? as usize;
+                    AnnouncementSelector {
+                        block_selector: BlockSelector::Tip,
+                        index,
+                    }
+                }
+                _ => unreachable!(),
+            };
+
+            Ok(selector)
+        }
+
+        fn size_hint(_depth: usize) -> (usize, Option<usize>) {
+            // Not very precise, but enough for fuzzing/proptesting
+            (1, None)
+        }
+    }
+
+    #[proptest]
+    fn display_roundtrip(#[strategy(arb())] announcement_selector: AnnouncementSelector) {
+        let as_string = announcement_selector.to_string();
+        let parsed = AnnouncementSelector::from_str(&as_string).unwrap();
+        prop_assert_eq!(announcement_selector, parsed.clone());
+
+        let as_string_again = parsed.to_string();
+        prop_assert_eq!(as_string, as_string_again);
+    }
+
+    #[proptest]
+    fn parse_height_or_digest_digest(
+        #[strategy(arb())] digest: Digest,
+        #[strategy(0usize..20)] index: usize,
+    ) {
+        let str = format!("height_or_digest/{digest:x}/index/{index}");
+        AnnouncementSelector::from_str(&str).unwrap(); // no crash
+    }
+
+    #[proptest]
+    fn parse_height_or_digest_height(
+        #[strategy(arb())] block_height: u64,
+        #[strategy(0usize..20)] index: usize,
+    ) {
+        let str = format!("height_or_digest/{block_height}/index/{index}");
+        AnnouncementSelector::from_str(&str).unwrap(); // no crash
+    }
+
+    #[proptest]
+    fn parse_invalid_number_of_parts(s: String) {
+        // Strings with fewer than 2 parts OR more than 3 parts should fail
+        let parts: Vec<&str> = s.split('/').collect();
+        if !(2..=4).contains(&parts.len()) {
+            let res = AnnouncementSelector::from_str(&s);
+            prop_assert!(matches!(
+                res,
+                Err(AnnouncementSelectorParseError::NumberOfParts)
+            ));
+        }
+    }
+
+    #[proptest]
+    fn parse_invalid_tip_index(#[strategy(string_regex("tip/[a-z]+").unwrap())] s: String) {
+        let res = AnnouncementSelector::from_str(&s);
+        prop_assert!(matches!(
+            res,
+            Err(AnnouncementSelectorParseError::TipIndex(_))
+        ));
+    }
+
+    #[proptest]
+    fn parse_invalid_genesis_index(#[strategy(string_regex("genesis/[a-z]+").unwrap())] s: String) {
+        let res = AnnouncementSelector::from_str(&s);
+        prop_assert!(matches!(
+            res,
+            Err(AnnouncementSelectorParseError::GenesisIndex(_))
+        ));
+    }
+
+    #[proptest]
+    fn parse_invalid_height_number(
+        #[strategy(string_regex("height/[a-z]+/0").unwrap())] s: String,
+    ) {
+        let res = AnnouncementSelector::from_str(&s);
+        prop_assert!(matches!(
+            res,
+            Err(AnnouncementSelectorParseError::BlockHeight(_))
+        ));
+    }
+
+    #[proptest]
+    fn parse_invalid_height_index(
+        #[strategy(string_regex("height/42/[a-z]+").unwrap())] s: String,
+    ) {
+        let res = AnnouncementSelector::from_str(&s);
+        if let Err(AnnouncementSelectorParseError::HeightIndex(_, _)) = res {
+            // OK
+        } else {
+            panic!("Expected HeightIndex error, got {res:?}");
+        }
+    }
+
+    #[proptest]
+    fn parse_invalid_digest_hex(
+        #[strategy(string_regex("digest/z[0-9a-f]{79}/0").unwrap())] s: String,
+    ) {
+        let res = AnnouncementSelector::from_str(&s);
+        prop_assert!(matches!(
+            res,
+            Err(AnnouncementSelectorParseError::BlockDigest(_))
+        ));
+    }
+
+    #[proptest]
+    fn parse_invalid_digest_length_too_short(
+        #[strategy(string_regex("digest/[0-9a-f]{0,79}/0").unwrap())] s: String,
+    ) {
+        let res = AnnouncementSelector::from_str(&s);
+        prop_assert!(matches!(
+            res,
+            Err(AnnouncementSelectorParseError::BlockDigest(_))
+        ));
+    }
+
+    #[proptest]
+    fn parse_invalid_digest_length_too_long(
+        #[strategy(string_regex("digest/[0-9a-f]{81,200}/0").unwrap())] s: String,
+    ) {
+        let res = AnnouncementSelector::from_str(&s);
+        prop_assert!(matches!(
+            res,
+            Err(AnnouncementSelectorParseError::BlockDigest(_))
+        ));
+    }
+
+    #[proptest]
+    fn parse_invalid_digest_index(#[strategy(arb())] digest: Digest) {
+        let s = format!("digest/{digest:x}/notanumber");
+        let res = AnnouncementSelector::from_str(&s);
+        prop_assert!(matches!(
+            res,
+            Err(AnnouncementSelectorParseError::DigestIndex(_, _))
+        ));
+    }
+}

--- a/src/model/announcement_type.rs
+++ b/src/model/announcement_type.rs
@@ -1,0 +1,29 @@
+use neptune_cash::api::export::Announcement;
+use neptune_cash::api::export::TransparentTransactionInfo;
+use neptune_cash::prelude::triton_vm::prelude::BFieldElement;
+
+#[derive(Debug, Clone)]
+pub enum AnnouncementType {
+    Unknown(Vec<BFieldElement>),
+    TransparentTxInfo(TransparentTransactionInfo),
+}
+
+impl AnnouncementType {
+    pub fn parse(announcement: Announcement) -> Self {
+        if let Ok(transparent_transaction_info) =
+            TransparentTransactionInfo::try_from_announcement(&announcement)
+        {
+            Self::TransparentTxInfo(transparent_transaction_info)
+        } else {
+            Self::Unknown(announcement.message)
+        }
+    }
+
+    pub fn name(&self) -> String {
+        match self {
+            AnnouncementType::Unknown(_) => "unknown",
+            AnnouncementType::TransparentTxInfo(_) => "transparent transaction info",
+        }
+        .to_string()
+    }
+}

--- a/src/model/app_state.rs
+++ b/src/model/app_state.rs
@@ -92,7 +92,7 @@ impl AppState {
             rpc_client,
             config: inner.config.clone(),
             genesis_digest: inner.genesis_digest,
-            transparent_utxos_cache: Arc::new(Mutex::new(vec![])),
+            transparent_utxos_cache: inner.transparent_utxos_cache.clone(),
         };
         self.0.store(Arc::new(new_inner));
     }

--- a/src/model/app_state.rs
+++ b/src/model/app_state.rs
@@ -9,6 +9,7 @@ use neptune_cash::prelude::twenty_first::tip5::Digest;
 use neptune_cash::rpc_auth;
 use std::sync::Arc;
 
+#[derive(Debug, Clone)]
 pub struct AppStateInner {
     pub network: Network,
     pub config: Config,

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -4,3 +4,4 @@ pub mod app_state;
 pub mod block_selector_extended;
 pub mod config;
 pub mod height_or_digest;
+pub mod transparent_utxo_tuple;

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,3 +1,5 @@
+pub mod announcement_selector;
+pub mod announcement_type;
 pub mod app_state;
 pub mod block_selector_extended;
 pub mod config;

--- a/src/model/transparent_utxo_tuple.rs
+++ b/src/model/transparent_utxo_tuple.rs
@@ -1,0 +1,119 @@
+use neptune_cash::api::export::AdditionRecord;
+use neptune_cash::api::export::Digest;
+use neptune_cash::api::export::TransparentInput;
+use neptune_cash::api::export::Utxo;
+use neptune_cash::api::export::UtxoTriple;
+
+#[derive(Debug, Clone)]
+pub struct TransparentUtxoTuple {
+    utxo: Utxo,
+    sender_randomness: Digest,
+    receiver_preimage: Option<Digest>,
+    receiver_digest: Digest,
+    aocl_leaf_index: Option<u64>,
+    spent_in_block: Vec<Digest>,
+    confirmed_in_block: Option<Digest>,
+    addition_record: AdditionRecord,
+}
+
+impl TransparentUtxoTuple {
+    pub fn new_from_transparent_input(
+        transparent_input: &TransparentInput,
+        spent_in_block: Digest,
+    ) -> Self {
+        Self {
+            utxo: transparent_input.utxo.clone(),
+            sender_randomness: transparent_input.sender_randomness,
+            receiver_preimage: Some(transparent_input.receiver_preimage),
+            receiver_digest: transparent_input.receiver_preimage.hash(),
+            aocl_leaf_index: Some(transparent_input.aocl_leaf_index),
+            spent_in_block: vec![spent_in_block],
+            confirmed_in_block: None,
+            addition_record: transparent_input.addition_record(),
+        }
+    }
+
+    pub fn upgrade_with_transparent_output(&mut self, confirmed_in_block: Digest) {
+        self.set_confirmed_in_block(confirmed_in_block);
+    }
+
+    pub fn new_from_transparent_output(
+        utxo_triple: &UtxoTriple,
+        aocl_leaf_index: Option<u64>,
+        confirmed_in_block: Digest,
+    ) -> Self {
+        Self {
+            utxo: utxo_triple.utxo.clone(),
+            sender_randomness: utxo_triple.sender_randomness,
+            receiver_preimage: None,
+            receiver_digest: utxo_triple.receiver_digest,
+            aocl_leaf_index,
+            spent_in_block: vec![],
+            confirmed_in_block: Some(confirmed_in_block),
+            addition_record: utxo_triple.addition_record(),
+        }
+    }
+
+    pub fn upgrade_with_transparent_input(
+        &mut self,
+        transparent_input: &TransparentInput,
+        spent_in_block: Digest,
+    ) {
+        self.set_receiver_preimage(transparent_input.receiver_preimage);
+        self.set_spent_in_block(spent_in_block);
+    }
+
+    pub fn set_receiver_preimage(&mut self, receiver_preimage: Digest) {
+        if self.receiver_preimage.is_none() && receiver_preimage.hash() == self.receiver_digest {
+            self.receiver_preimage = Some(receiver_preimage);
+        }
+    }
+
+    pub fn set_spent_in_block(&mut self, block_digest: Digest) {
+        if !self.spent_in_block.contains(&block_digest) {
+            self.spent_in_block.push(block_digest);
+        }
+    }
+
+    pub fn set_confirmed_in_block(&mut self, block_digest: Digest) {
+        if self.confirmed_in_block.is_none() {
+            self.confirmed_in_block = Some(block_digest);
+        }
+    }
+
+    pub fn utxo(&self) -> Utxo {
+        self.utxo.clone()
+    }
+
+    pub fn sender_randomness(&self) -> Digest {
+        self.sender_randomness
+    }
+
+    pub fn receiver_preimage(&self) -> Option<Digest> {
+        self.receiver_preimage
+    }
+
+    pub fn receiver_digest(&self) -> Digest {
+        if let Some(receiver_preimage) = self.receiver_preimage {
+            receiver_preimage.hash()
+        } else {
+            self.receiver_digest
+        }
+    }
+
+    pub fn aocl_leaf_index(&self) -> Option<u64> {
+        self.aocl_leaf_index
+    }
+
+    pub fn spent_in_block(&self) -> Vec<Digest> {
+        self.spent_in_block.clone()
+    }
+
+    pub fn confirmed_in_block(&self) -> Option<Digest> {
+        self.confirmed_in_block
+    }
+
+    pub fn addition_record(&self) -> AdditionRecord {
+        self.addition_record
+    }
+}

--- a/src/rpc/utxo_digest.rs
+++ b/src/rpc/utxo_digest.rs
@@ -18,9 +18,10 @@ pub async fn utxo_digest(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<Digest>, impl IntoResponse> {
     let s = state.load();
+    let cache = s.transparent_utxos_cache.clone();
     match s
         .rpc_client
-        .utxo_digest(context::current(), s.token(), index)
+        .utxo_digest(context::current(), s.token(), index, cache)
         .await
         .map_err(rpc_err)?
         .map_err(rpc_method_err)?

--- a/templates/web/html/page/announcement.html
+++ b/templates/web/html/page/announcement.html
@@ -1,0 +1,150 @@
+<html>
+
+<head>
+    <title>{{self.header.state.config.site_name}}: Announcement {{self.block_height}}/{{self.index}}</title>
+    {{html_escaper::Trusted(include_str!( concat!(env!("CARGO_MANIFEST_DIR"),
+    "/templates/web/html/components/head.html")))}}
+</head>
+
+<body>
+    {{Trusted(self.header.to_string())}}
+
+    <main class="container">
+
+        <article>
+            <h2>Announcement
+            </h2>
+            <h3>
+                Metadata
+            </h3>
+            <table class="striped">
+                <tr>
+                    <td>Block Height</td>
+                    <td><a href='/block/digest/{{self.block_hash.to_hex()}}'>{{self.block_height}}</a></td>
+                </tr>
+                <tr>
+                    <td>Block Hash</td>
+                    <td class="mono"><a
+                            href='/block/digest/{{self.block_hash.to_hex()}}'>{{self.block_hash.to_hex()}}</a></td>
+                </tr>
+                <tr>
+                    <td>Index</td>
+                    <td>{{self.index}}/{{self.num_announcements}}</td>
+                </tr>
+                <tr>
+                    <td>Type</td>
+                    <td>{{self.announcement_type.name()}}</td>
+                </tr>
+            </table>
+            <h3>Payload</h3>
+            {% match &self.announcement_type { AnnouncementType::TransparentTxInfo(tx_info) => { %}
+            <details open>
+                <summary>Transparent Transaction Info</summary>
+                <table class="striped">
+                    <tr>
+                        <th colspan=2 style="font-weight: bold;">inputs</th>
+                    </tr>
+                    {% for input in tx_info.inputs.iter() { %}
+                    <tr>
+                        <td>
+                            <details>
+                                <summary>
+                                    <a
+                                        href='/utxo/{{input.aocl_leaf_index}}'>{{input.addition_record().canonical_commitment.to_hex()}}</a>
+                                </summary>
+                                <table>
+                                    <tr>
+                                        <td>UTXO digest:</td>
+                                        <td class="mono">{{Tip5::hash(&input.utxo).to_hex()}}</td>
+                                    </tr>
+                                    <tr>
+                                        <td>sender randomness:</td>
+                                        <td class="mono">{{input.sender_randomness.to_hex()}}</td>
+                                    </tr>
+                                    <tr>
+                                        <td>receiver preimage:</td>
+                                        <td class="mono">{{input.receiver_preimage.to_hex()}}</td>
+                                    </tr>
+                                </table>
+                            </details>
+                        </td>
+                        <td style="text-align: right" class="mono">
+                            {{input.utxo.get_native_currency_amount().display_n_decimals(5)}}
+                            NPT
+                        </td>
+                    </tr>
+                    {% } %}
+                </table>
+                <table class="striped">
+                    <tr>
+                        <th colspan="2" style="font-weight: bold;">outputs</th>
+                    </tr>
+                    {% for output in tx_info.outputs.iter() { %}
+                    <tr>
+                        <td>
+                            <details>
+                                <summary>
+                                    {{output.addition_record().canonical_commitment.to_hex()}}
+                                </summary>
+                                <table>
+                                    <tr>
+                                        <td>UTXO digest:</td>
+                                        <td class="mono">{{Tip5::hash(&output.utxo).to_hex()}}</td>
+                                    </tr>
+                                    <tr>
+                                        <td>sender randomness:</td>
+                                        <td class="mono">{{output.sender_randomness.to_hex()}}</td>
+                                    </tr>
+                                    <tr>
+                                        <td>receiver digest:</td>
+                                        <td class="mono">{{output.receiver_digest.to_hex()}}</td>
+                                    </tr>
+                                </table>
+                            </details>
+                        </td>
+                        <td style="text-align: right" class="mono">
+                            {{output.utxo.get_native_currency_amount().display_n_decimals(5)}}
+                            NPT
+                        </td>
+                    </tr>
+                    {% } %}
+                </table>
+            </details>
+            {% }, AnnouncementType::Unknown(payload) => { %}
+            <details>
+                <summary>Unknown Type</summary>
+                {% for chunk in payload.encode().chunks(4) { %}
+                <p class="mono">
+                    {% for d in chunk { %}
+                    {{ format!("{:016x}", d.value()) }}
+                    {% } %}
+                </p>
+                {% } %}
+            </details>
+            {% }, } %}
+        </article>
+
+        <article>
+            <p>
+                <a href="/">Home</a>
+                | <a href='/block/genesis'>Genesis</a>
+                | <a href='/block/tip'>Tip</a>
+                {% if self.index == 0 { %}
+                | Previous Announcement
+                {% } else { %}
+                | <a href='/announcement/digest/{{self.block_hash.to_hex()}}/{{self.index - 1}}'>Previous
+                    Announcement</a>
+                {% } %}
+
+                {% if self.index+1 >= self.num_announcements { %}
+                | Next Announcement
+                {% } else { %}
+                | <a href='/announcement/digest/{{self.block_hash.to_hex()}}/{{self.index + 1}}'>Next Announcement</a>
+                {% } %}
+            </p>
+        </article>
+
+    </main>
+</body>
+
+</html>

--- a/templates/web/html/page/announcement.html
+++ b/templates/web/html/page/announcement.html
@@ -40,6 +40,7 @@
             {% match &self.announcement_type { AnnouncementType::TransparentTxInfo(tx_info) => { %}
             <details open>
                 <summary>Transparent Transaction Info</summary>
+                {% if !tx_info.inputs.is_empty() { %}
                 <table class="striped">
                     <tr>
                         <th colspan=2 style="font-weight: bold;">inputs</th>
@@ -75,6 +76,8 @@
                     </tr>
                     {% } %}
                 </table>
+                {% } %}
+                {% if !tx_info.outputs.is_empty() { %}
                 <table class="striped">
                     <tr>
                         <th colspan="2" style="font-weight: bold;">outputs</th>
@@ -109,6 +112,7 @@
                     </tr>
                     {% } %}
                 </table>
+                {% } %}
             </details>
             {% }, AnnouncementType::Unknown(payload) => { %}
             <details>

--- a/templates/web/html/page/announcement.html
+++ b/templates/web/html/page/announcement.html
@@ -87,7 +87,13 @@
                         <td>
                             <details>
                                 <summary>
+                                    {% if let Some(Some(aocl_leaf_index)) =
+                                    self.addition_record_indices.get(&output.addition_record()) { %}
+                                    <a
+                                        href='/utxo/{{aocl_leaf_index}}'>{{output.addition_record().canonical_commitment.to_hex()}}</a>
+                                    {% } else { %}
                                     {{output.addition_record().canonical_commitment.to_hex()}}
+                                    {% } %}
                                 </summary>
                                 <table>
                                     <tr>

--- a/templates/web/html/page/block_info.html
+++ b/templates/web/html/page/block_info.html
@@ -3,140 +3,164 @@
 
 <head>
     <title>{{self.header.state.config.site_name}}: Block Height {{self.block_info.height}}</title>
-{{html_escaper::Trusted(include_str!(concat!(env!("CARGO_MANIFEST_DIR"),"/templates/web/html/components/head.html")))}}
+    {{html_escaper::Trusted(include_str!(concat!(env!("CARGO_MANIFEST_DIR"),"/templates/web/html/components/head.html")))}}
 </head>
 
 <body>
-{{Trusted(self.header.to_string())}}
+    {{Trusted(self.header.to_string())}}
 
-<main class="container">
+    <main class="container">
 
-<article>
-    <h2>Block height: {{self.block_info.height}}</h2>
+        <article>
+            <h2>Block height: {{self.block_info.height}}</h2>
 
-<!-- special_block_notice -->
-%%  if self.block_info.is_genesis {
-        <p>This is the genesis block</p>
-%%  }
-%%  if self.block_info.is_tip {
-        <p>This is the latest block (tip)</p>
-%%  }
+            <!-- special_block_notice -->
+            %% if self.block_info.is_genesis {
+            <p>This is the genesis block</p>
+            %% }
+            %% if self.block_info.is_tip {
+            <p>This is the latest block (tip)</p>
+            %% }
 
-    <table class="striped">
-        <tr>
-            <td>Digest</td>
-            <td class="mono">{{self.block_info.digest.to_hex()}}</td>
-        </tr>
-        <tr>
-            <td>Created</td>
-            <td>{{self.block_info.timestamp.standard_format()}}</td>
-        </tr>
-        <tr>
-            <td>Size
-                <span class="tooltip">ⓘ
-                    <span class="tooltiptext">Unit: number of BFieldElements. One BFieldElement consists of 8 bytes.</span>
-                </span>
-            </td>
-            <td>{{self.block_info.size}}</td>
-        </tr>
-        <tr>
-            <td>Inputs</td>
-            <td>{{self.block_info.num_inputs}}<br /></td>
-        </tr>
-        <tr>
-            <td>Outputs</td>
-            <td>{{self.block_info.num_outputs}}</td>
-        </tr>
-        <tr>
-            <td>Difficulty</td>
-            <td>{{self.block_info.difficulty}}</td>
-        </tr>
-        <tr>
-            <td>Cumulative Proof-Of-Work
-                <span class="tooltip">ⓘ
-                    <span class="tooltiptext">estimated total # of hashes performed by miners from genesis block to this block.</span>
-                </span>
-            </td>
-            <td>{{self.block_info.cumulative_proof_of_work}}</td>
-        </tr>
-        <tr>
-            <td>Coinbase
-                <span class="tooltip">ⓘ
-                    <span class="tooltiptext">Total block reward amount paid to the miner(s) that found this block.</span>
-                </span>
-            </td>
-            <td>{{self.block_info.coinbase_amount}}</td>
-        </tr>
-%% if self.block_info.coinbase_amount != self.block_info.expected_coinbase_amount() {
-        <tr>
-            <td>Expected Coinbase
-                <span class="tooltip">ⓘ
-                    <span class="tooltiptext">Expected (maximum) block reward amount paid to the miner(s) that find a block at this block-height.</span>
-                </span>
-            </td>
-            <td>{{self.block_info.expected_coinbase_amount()}}</td>
-        </tr>
-%% }
-        <tr>
-            <td>Fee</td>
-            <td>{{self.block_info.fee}}</td>
-        </tr>
-        <tr>
-            <td>Canonical
-                <span class="tooltip">ⓘ
-                    <span class="tooltiptext">
-                        The canonical blockchain is the chain with the most accumulated proof-of-work and is considered the
-                        official record of transaction history.
-                    </span>
-                </span>
-            </td>
-            <td>
-                %% if self.block_info.is_canonical {
-                Yes.  This block is in the canonical blockchain.
-                %% } else {
-                No.  This block is not in the canonical blockchain.
+            <table class="striped">
+                <tr>
+                    <td>Digest</td>
+                    <td class="mono">{{self.block_info.digest.to_hex()}}</td>
+                </tr>
+                <tr>
+                    <td>Created</td>
+                    <td>{{self.block_info.timestamp.standard_format()}}</td>
+                </tr>
+                <tr>
+                    <td>Size
+                        <span class="tooltip">ⓘ
+                            <span class="tooltiptext">Unit: number of BFieldElements. One BFieldElement consists of 8
+                                bytes.</span>
+                        </span>
+                    </td>
+                    <td>{{self.block_info.size}}</td>
+                </tr>
+                <tr>
+                    <td>Inputs</td>
+                    <td>{{self.block_info.num_inputs}}<br /></td>
+                </tr>
+                <tr>
+                    <td>Outputs</td>
+                    <td>{{self.block_info.num_outputs}}</td>
+                </tr>
+                <tr>
+                    <td>Announcements
+                        <span class="tooltip">ⓘ
+                            <span class="tooltiptext">
+                                Data broadcast as part of the transaction.
+                            </span>
+                        </span>
+                    </td>
+                    <td>
+                        {% if self.block_info.num_announcements > 0 { %}
+                        <a
+                            href='/announcement/digest/{{self.block_info.digest.to_hex()}}/0'>{{self.block_info.num_announcements}}</a>
+                        {% } else { %}
+                        0
+                        {% } %}
+                    </td>
+                </tr>
+                <tr>
+                    <td>Difficulty</td>
+                    <td>{{self.block_info.difficulty}}</td>
+                </tr>
+                <tr>
+                    <td>Cumulative Proof-Of-Work
+                        <span class="tooltip">ⓘ
+                            <span class="tooltiptext">estimated total # of hashes performed by miners from genesis block
+                                to this block.</span>
+                        </span>
+                    </td>
+                    <td>{{self.block_info.cumulative_proof_of_work}}</td>
+                </tr>
+                <tr>
+                    <td>Coinbase
+                        <span class="tooltip">ⓘ
+                            <span class="tooltiptext">Total block reward amount paid to the miner(s) that found this
+                                block.</span>
+                        </span>
+                    </td>
+                    <td>{{self.block_info.coinbase_amount}}</td>
+                </tr>
+                %% if self.block_info.coinbase_amount != self.block_info.expected_coinbase_amount() {
+                <tr>
+                    <td>Expected Coinbase
+                        <span class="tooltip">ⓘ
+                            <span class="tooltiptext">Expected (maximum) block reward amount paid to the miner(s) that
+                                find a block at this block-height.</span>
+                        </span>
+                    </td>
+                    <td>{{self.block_info.expected_coinbase_amount()}}</td>
+                </tr>
                 %% }
-            </td>
-        </tr>
-        <tr>
-            <td>Sibling Blocks
-                <span class="tooltip">ⓘ
-                    <span class="tooltiptext">
-                        Blocks that exist at the same height as this block. Only one sibling can be in the canonical blockchain.
-                    </span>
-                </span>
-            </td>
-            <td class="mono">
-%% for sibling_digest in self.block_info.sibling_blocks.iter().map(|d| d.to_hex()) {
-<a href='/block/digest/{{sibling_digest}}'>{{sibling_digest}}</a><br/>
-%% }
-            </td>
-        </tr>
+                <tr>
+                    <td>Fee</td>
+                    <td>{{self.block_info.fee}}</td>
+                </tr>
+                <tr>
+                    <td>Canonical
+                        <span class="tooltip">ⓘ
+                            <span class="tooltiptext">
+                                The canonical blockchain is the chain with the most accumulated proof-of-work and is
+                                considered the
+                                official record of transaction history.
+                            </span>
+                        </span>
+                    </td>
+                    <td>
+                        %% if self.block_info.is_canonical {
+                        Yes. This block is in the canonical blockchain.
+                        %% } else {
+                        No. This block is not in the canonical blockchain.
+                        %% }
+                    </td>
+                </tr>
+                <tr>
+                    <td>Sibling Blocks
+                        <span class="tooltip">ⓘ
+                            <span class="tooltiptext">
+                                Blocks that exist at the same height as this block. Only one sibling can be in the
+                                canonical blockchain.
+                            </span>
+                        </span>
+                    </td>
+                    <td class="mono">
+                        %% for sibling_digest in self.block_info.sibling_blocks.iter().map(|d| d.to_hex()) {
+                        <a href='/block/digest/{{sibling_digest}}'>{{sibling_digest}}</a><br />
+                        %% }
+                    </td>
+                </tr>
 
-    </table>
+            </table>
 
-</article>
+        </article>
 
-<article>
+        <article>
 
-    <p>
-        <a href="/">Home</a>
-        | <a href='/block/genesis'>Genesis</a>
-        | <a href='/block/tip'>Tip</a>
-%% if self.block_info.is_genesis {
-        | Previous Block
-%% } else {
-        | <a href='/block/height/{{self.block_info.height.previous().unwrap()}}'>Previous Block</a>
-%% }
+            <p>
+                <a href="/">Home</a>
+                | <a href='/block/genesis'>Genesis</a>
+                | <a href='/block/tip'>Tip</a>
+                %% if self.block_info.is_genesis {
+                | Previous Block
+                %% } else {
+                | <a href='/block/height/{{self.block_info.height.previous().unwrap()}}'>Previous Block</a>
+                %% }
 
-%% if self.block_info.is_tip {
-        | Next Block
-%% } else {
-        | <a href='/block/height/{{self.block_info.height.next()}}'>Next Block</a>
-%% }
-    </p>
+                %% if self.block_info.is_tip {
+                | Next Block
+                %% } else {
+                | <a href='/block/height/{{self.block_info.height.next()}}'>Next Block</a>
+                %% }
+            </p>
 
-</article>
-</main>
+        </article>
+    </main>
 </body>
+
 </html>

--- a/templates/web/html/page/root.html
+++ b/templates/web/html/page/root.html
@@ -1,113 +1,152 @@
 <html>
+
 <head>
     <title>{{self.state.config.site_name}}: (network: {{self.state.network}})</title>
-{{ html_escaper::Trusted(include_str!( concat!(env!("CARGO_MANIFEST_DIR"), "/templates/web/html/components/head.html"))) }}
+    {{ html_escaper::Trusted(include_str!( concat!(env!("CARGO_MANIFEST_DIR"),
+    "/templates/web/html/components/head.html"))) }}
 </head>
+
 <body>
-<header class="container">
-<h1>
-    <img src="/image/neptune-logo-circle-small.png" align="right"/>
-    {{self.state.config.site_name}} (network: {{self.state.network}})
-</h1>
-The blockchain tip is at height: {{self.tip_height}}
-</header>
+    <header class="container">
+        <h1>
+            <img src="/image/neptune-logo-circle-small.png" align="right" />
+            {{self.state.config.site_name}} (network: {{self.state.network}})
+        </h1>
+        The blockchain tip is at height: {{self.tip_height}}
+    </header>
 
-<main class="container">
+    <main class="container">
 
-<article>
-<details open>
-<summary>
-    Block Lookup
-</summary>
-<form action="/rqs" method="get">
-<input type="hidden" name="block" value="" />
-<input type="hidden" name="_ig" value="l"/>
-<span class="tooltip">ⓘ
-    <span class="tooltiptext">
-        Provide a numeric block height or hexadecimal digest identifier to lookup any block in the Neptune blockchain.
-    </span>
-</span>
+        <article>
+            <details open>
+                <summary>
+                    Block Lookup
+                </summary>
+                <form action="/rqs" method="get">
+                    <input type="hidden" name="block" value="" />
+                    <input type="hidden" name="_ig" value="l" />
+                    <span class="tooltip">ⓘ
+                        <span class="tooltiptext">
+                            Provide a numeric block height or hexadecimal digest identifier to lookup any block in the
+                            Neptune blockchain.
+                        </span>
+                    </span>
 
-Block height or digest:
-<input type="text" size="80" name="height_or_digest" class="mono"/>
-<input type="submit" name="l" value="Lookup Block"/>
-</form>
+                    Block height or digest:
+                    <input type="text" size="80" name="height_or_digest" class="mono" />
+                    <input type="submit" name="l" value="Lookup Block" />
+                </form>
 
-Quick Lookup:
-    <a href="/block/genesis">Genesis Block</a> |
-    <a href="/block/tip">Tip</a><br/>
-</details>
-</article>
+                Quick Lookup:
+                <a href="/block/genesis">Genesis Block</a> |
+                <a href="/block/tip">Tip</a><br />
+            </details>
+        </article>
 
-<article>
-<details open>
-<summary>UTXO Lookup</summary>
-<form action="/rqs" method="get">
-<input type="hidden" name="_ig" value="l" />
-    <span class="tooltip">ⓘ
-        <span class="tooltiptext">
-            An Unspent Transaction Output (UTXO) index can be found in the output of <i>neptune-cli wallet-status</i>.  Look for the field: <b>aocl_leaf_index</b>
-        </span>
-    </span>
-    UTXO index:
-    <input type="text" size="10" name="utxo" />
-    <input type="submit" name="l" value="Lookup Utxo" />
-</form>
-</details>
-</article>
+        <article>
+            <details open>
+                <summary>UTXO Lookup</summary>
+                <form action="/rqs" method="get">
+                    <input type="hidden" name="_ig" value="l" />
+                    <span class="tooltip">ⓘ
+                        <span class="tooltiptext">
+                            An Unspent Transaction Output (UTXO) index can be found in the output of <i>neptune-cli
+                                wallet-status</i>. Look for the field: <b>aocl_leaf_index</b>
+                        </span>
+                    </span>
+                    UTXO index:
+                    <input type="text" size="10" name="utxo" />
+                    <input type="submit" name="l" value="Lookup Utxo" />
+                </form>
+            </details>
+        </article>
 
-<article>
-<details>
-<summary>REST RPCs</summary>
-<section>
-RPC endpoints are available for automating block explorer queries:
-</section>
+        <article>
+            <details open>
+                <summary>Announcement Lookup</summary>
+                <form action="/rqs" method="get">
+                    <input type="hidden" name="announcement" value="" />
+                    <input type="hidden" name="_ig" value="l" />
+                    <span class="tooltip">ⓘ
+                        <span class="tooltiptext">
+                            A numeric block height or hexadecimal digest to identify the block in which the announcement
+                            lives.
+                        </span>
+                    </span>
+                    Block height or digest:
+                    <input type="text" size="80" name="height_or_digest" class="mono" />
 
-<details>
-<summary>/block_info</summary>
-<div class="indent">
-    <h4>Examples</h4>
+                    <span class="tooltip">ⓘ
+                        <span class="tooltiptext">
+                            The index of the announcement within the block (as a block can have many announcements).
+                        </span>
+                    </span>
+                    Announcement index:
+                    <input type="text" size="10" name="index" />
+                    <input type="submit" name="l" value="Lookup Announcement" />
+                </form>
+            </details>
+        </article>
 
-    <ul>
-    <li><a href="/rpc/block_info/genesis">/rpc/block_info/genesis</a></li>
-    <li><a href="/rpc/block_info/tip">/rpc/block_info/tip</a></li>
-    <li><a href="/rpc/block_info/height/2">/rpc/block_info/height/2</a></li>
-    <li><a href="/rpc/block_info/digest/{{self.state.genesis_digest.to_hex()}}">/rpc/block_info/digest/{{self.state.genesis_digest.to_hex()}}</a></li>
-    <li><a href="/rpc/block_info/height_or_digest/1">/rpc/block_info/height_or_digest/1</a></li>
-    </ul>
-</div>
-</details>
+        <article>
+            <details>
+                <summary>REST RPCs</summary>
+                <section>
+                    RPC endpoints are available for automating block explorer queries:
+                </section>
 
-<details>
-<summary>/block_digest</summary>
-<div class="indent">
-    <h4>Examples</h4>
+                <details>
+                    <summary>/block_info</summary>
+                    <div class="indent">
+                        <h4>Examples</h4>
 
-    <ul>
-    <li><a href="/rpc/block_digest/genesis">/rpc/block_digest/genesis</a></li>
-    <li><a href="/rpc/block_digest/tip">/rpc/block_digest/tip</a></li>
-    <li><a href="/rpc/block_digest/height/2">/rpc/block_digest/height/2</a></li>
-    <li><a href="/rpc/block_digest/digest/{{self.state.genesis_digest.to_hex()}}">/rpc/block_digest/digest/{{self.state.genesis_digest.to_hex()}}</a></li>
-    <li><a href="/rpc/block_digest/height_or_digest/{{self.state.genesis_digest.to_hex()}}">/rpc/block_digest/height_or_digest/{{self.state.genesis_digest.to_hex()}}</a></li>
-    </ul>
-</div>
-</details>
+                        <ul>
+                            <li><a href="/rpc/block_info/genesis">/rpc/block_info/genesis</a></li>
+                            <li><a href="/rpc/block_info/tip">/rpc/block_info/tip</a></li>
+                            <li><a href="/rpc/block_info/height/2">/rpc/block_info/height/2</a></li>
+                            <li><a
+                                    href="/rpc/block_info/digest/{{self.state.genesis_digest.to_hex()}}">/rpc/block_info/digest/{{self.state.genesis_digest.to_hex()}}</a>
+                            </li>
+                            <li><a href="/rpc/block_info/height_or_digest/1">/rpc/block_info/height_or_digest/1</a></li>
+                        </ul>
+                    </div>
+                </details>
 
-<details>
-<summary>/utxo_digest</summary>
-<div class="indent">
-    <h4>Examples</h4>
+                <details>
+                    <summary>/block_digest</summary>
+                    <div class="indent">
+                        <h4>Examples</h4>
 
-    <ul>
-    <li><a href="/rpc/utxo_digest/2">/rpc/utxo_digest/2</a><br/></li>
-    </ul>
-</div>
-</details>
+                        <ul>
+                            <li><a href="/rpc/block_digest/genesis">/rpc/block_digest/genesis</a></li>
+                            <li><a href="/rpc/block_digest/tip">/rpc/block_digest/tip</a></li>
+                            <li><a href="/rpc/block_digest/height/2">/rpc/block_digest/height/2</a></li>
+                            <li><a
+                                    href="/rpc/block_digest/digest/{{self.state.genesis_digest.to_hex()}}">/rpc/block_digest/digest/{{self.state.genesis_digest.to_hex()}}</a>
+                            </li>
+                            <li><a
+                                    href="/rpc/block_digest/height_or_digest/{{self.state.genesis_digest.to_hex()}}">/rpc/block_digest/height_or_digest/{{self.state.genesis_digest.to_hex()}}</a>
+                            </li>
+                        </ul>
+                    </div>
+                </details>
 
-</details>
-</article>
+                <details>
+                    <summary>/utxo_digest</summary>
+                    <div class="indent">
+                        <h4>Examples</h4>
 
-</main>
+                        <ul>
+                            <li><a href="/rpc/utxo_digest/2">/rpc/utxo_digest/2</a><br /></li>
+                        </ul>
+                    </div>
+                </details>
+
+            </details>
+        </article>
+
+    </main>
 
 </body>
+
 </html>

--- a/templates/web/html/page/utxo.html
+++ b/templates/web/html/page/utxo.html
@@ -75,6 +75,26 @@
                     <td><span class="mono">{{release_date.standard_format()}}</span></td>
                 </tr>
                 {% } %}
+                {% if let Some(confirmed_in) = utxo_info.confirmed_in_block() { %}
+                <tr>
+                    <td>Confirmed in Block:</td>
+                    <td><a href='/block/digest/{{confirmed_in.to_hex()}}'>{{confirmed_in.to_hex()}}</a></td>
+                </tr>
+                {% } %}
+                {% if !utxo_info.spent_in_block().is_empty() { %}
+                <tr>
+                    {% if utxo_info.spent_in_block().len() == 1 { %}
+                    <td>Spent in Block:</td>
+                    {% } else { %}
+                    <td>Spent in Blocks:</td>
+                    {% } %}
+                    <td>
+                        {% for b in utxo_info.spent_in_block() { %}
+                        <a href='/block/digest/{{b.to_hex()}}'>{{b.to_hex()}}</a>
+                        {% } %}
+                    </td>
+                </tr>
+                {% } %}
             </table>
         </article>
         {% } %}

--- a/templates/web/html/page/utxo.html
+++ b/templates/web/html/page/utxo.html
@@ -2,43 +2,92 @@
 
 <head>
     <title>{{self.header.state.config.site_name}}: Utxo {{self.index}}</title>
-{{html_escaper::Trusted(include_str!( concat!(env!("CARGO_MANIFEST_DIR"), "/templates/web/html/components/head.html")))}}
+    {{html_escaper::Trusted(include_str!( concat!(env!("CARGO_MANIFEST_DIR"),
+    "/templates/web/html/components/head.html")))}}
 </head>
 
 <body>
-{{Trusted(self.header.to_string())}}
+    {{Trusted(self.header.to_string())}}
 
-<main class="container">
+    <main class="container">
 
-<article>
-<summary>
-    <span class="tooltip">ⓘ
-        <span class="tooltiptext">
-            UTXO = Unspent Transaction Output.  It represents an output of transaction A which can also be an input to transaction B.
-        </span>
-    </span>
-    UTXO Information
-</summary>
-    <table class="striped">
-        <tr>
-            <td>Index</td>
-            <td>{{self.index}}</td>
-        </tr>
-        <tr>
-            <td>Digest</td>
-            <td>{{self.digest.to_hex()}}</td>
-        </tr>
-    </table>
-</article>
+        <article>
+            <summary>
+                <span class="tooltip">ⓘ
+                    <span class="tooltiptext">
+                        UTXO = Unspent Transaction Output. It represents an output of transaction A which can also be an
+                        input to transaction B.
+                    </span>
+                </span>
+                UTXO Information
+            </summary>
+            <table class="striped">
+                <tr>
+                    <td>AOCL Leaf Index</td>
+                    <td>{{self.index}}</td>
+                </tr>
+                <tr>
+                    <td>Addition Record</td>
+                    <td>{{self.digest.to_hex()}}</td>
+                </tr>
+            </table>
+        </article>
 
-<article>
-    <p>
-        <a href="/">Home</a>
-        | <a href='/block/genesis'>Genesis</a>
-        | <a href='/block/tip'>Tip</a>
-    </p>
-</article>
+        {% if let Some(utxo_info) = &self.transparent_utxo_info { %}
+        <article>
+            <summary>
+                <span class="tooltip">ⓘ
+                    <span class="tooltiptext">
+                        UTXOs consumed or produced by a transparent transaction disclose the information they otherwise
+                        hide.
+                    </span>
+                </span>
+                Transparent UTXO Information
+            </summary>
+            <table class="striped">
+                <tr>
+                    <td>UTXO Digest:</td>
+                    <td><span class="mono">{{Tip5::hash(&utxo_info.utxo()).to_hex()}}</span></td>
+                </tr>
+                <tr>
+                    <td>Sender Randomness:</td>
+                    <td><span class="mono">{{utxo_info.sender_randomness().to_hex()}}</span></td>
+                </tr>
+                <tr>
+                    <td>Receiver Digest</td>
+                    <td><span class="mono">{{utxo_info.receiver_digest().to_hex()}}</span></td>
+                </tr>
+                {% if let Some(receiver_preimage) = utxo_info.receiver_preimage() { %}
+                <tr>
+                    <td>Receiver Preimage</td>
+                    <td><span class="mono">{{receiver_preimage.to_hex()}}</span></td>
+                </tr>
+                {% } %}
+                {% if utxo_info.utxo().has_native_currency() { %}
+                <tr>
+                    <td>Amount:</td>
+                    <td>{{utxo_info.utxo().get_native_currency_amount().display_n_decimals(5)}} NPT</td>
+                </tr>
+                {% } %}
+                {% if let Some(release_date) = utxo_info.utxo().release_date() { %}
+                <tr>
+                    <td>Time-Locked Until</td>
+                    <td><span class="mono">{{release_date.standard_format()}}</span></td>
+                </tr>
+                {% } %}
+            </table>
+        </article>
+        {% } %}
 
-</main>
+        <article>
+            <p>
+                <a href="/">Home</a>
+                | <a href='/block/genesis'>Genesis</a>
+                | <a href='/block/tip'>Tip</a>
+            </p>
+        </article>
+
+    </main>
 </body>
+
 </html>


### PR DESCRIPTION
Every transaction can have zero or more announcements, which are essentially
messages that must be included across all future mergers and updates.
Announcements are typically used for transmitting information related to
receiving UTXOs, encrypted. However, a new use case is that of *transparent
transaction info*, which is an announcement containing the UTXOs and the
commitment randomnesses needed to reproduce the transaction's inputs and
outputs. With such a transparent transaction info announcement, third parties
can transparently audit transactions.

This PR adds a page for viewing announcements, and if the announcement can
be parsed as a transparent transaction info type announcement, then it is
rendered as such, complete with native currency amounts and linkable UTXOs
(where possible).

The path for accessing announcements is any of
 - `/announcement/digest/<hex-string>/<index>`
 - `/announcement/tip/<index>`
 - `/announcement/genesis/<index>`
 - `/announcement/height/<height>/<index>`
 - `/announcement/height_or_digest/<height-or-diges>/index/<index>`.
The last bullet point exists to support the quick lookup functionality, which is
also new. A `AnnouncementSelector` has display and from-string methods relating
these path formats to the relevant object. A suite of (prop)tests verifies
parsing.

Also, this PR enables mocking, which is useful when the neptune-core node
the explorer is connected to is outdated, unsynced, or for whatever reason does
not serve the desired data. The RPC client call is intercepted, and if it fails
and mocking is enabled, an imagined (pseudorandom) resource of the requested
type is returned. To enable mocking, compile with the "mock" feature flag and
set the "MOCK" environment variable.

To enable browser-based tracking of transparent funds, the UTXOs shown on a
transparent transaction info page are clickable and, when clicked, take you to the
matching UTXO page. The UTXO page typically only displays the digest (to clarify:
the *addition record*). However, the UTXO data that is disclosed in a transparent
transaction is cached when the announcement page is rendered, so that the 
UTXO page can display it too. New type `TransparentUtxoTuple` is added to enable
this cache.