### PR TITLE
Website Attack Countermeasures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "getrandom 0.3.4",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -288,7 +289,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -321,7 +322,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -376,6 +377,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.108",
+]
+
+[[package]]
+name = "axum_gcra"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b171b8669e7a83349c726cc857529da933b03c503ad64f6258e546e0ec924ca5"
+dependencies = [
+ "ahash",
+ "async-trait",
+ "axum 0.7.9",
+ "futures-util",
+ "http",
+ "pin-project-lite",
+ "scc",
+ "tokio",
+ "tower 0.4.13",
 ]
 
 [[package]]
@@ -1996,6 +2014,7 @@ dependencies = [
  "arbitrary",
  "arc-swap",
  "axum 0.7.9",
+ "axum_gcra",
  "blake3",
  "boilerplate",
  "chrono",
@@ -2784,7 +2803,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tower",
+ "tower 0.5.2",
  "tower-http 0.6.6",
  "tower-service",
  "url",
@@ -2900,6 +2919,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2913,6 +2941,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "security-framework"
@@ -3607,6 +3641,17 @@ dependencies = [
 
 [[package]]
 name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
@@ -3659,7 +3704,7 @@ dependencies = [
  "http-body",
  "iri-string",
  "pin-project-lite",
- "tower",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ test-strategy = "0.4.3"
 proptest = "1.9.0"
 arbitrary = "1.4.2"
 proptest-arbitrary-interop = "0.1.0"
+axum_gcra = "0.1.1"
 
 [patch.crates-io]
 neptune-cash = { git = "https://github.com/Neptune-Crypto/neptune-core.git", rev = "71f471a526a13ddd41ab4400e1a873471d03ede6" }

--- a/src/bin/high_rate_attack.rs
+++ b/src/bin/high_rate_attack.rs
@@ -1,27 +1,31 @@
 use futures::future::join_all;
+use neptune_explorer::path::ExplorerPath;
+use rand::rng;
+use rand::Rng;
 use reqwest::Client;
 use tokio::time::Instant;
 
+///
+/// Run with: `> cargo run --bin high_rate_attack --features "attacks"`
 #[tokio::main]
 async fn main() {
     let client = Client::new();
-    let url = "http://127.0.0.1:3000/your_endpoint";
-    let num_requests = 200; // adjust as needed
+    let root_url = "http://127.0.0.1:3000/";
+    let num_requests = 2000; // adjust as needed
     let concurrency = 20; // parallel tasks
 
     let start = Instant::now();
+    let mut rng = rng();
     let futures = (0..num_requests).map(|_| {
+        let path = rng.random::<ExplorerPath>().to_string();
         let client = &client;
         async move {
-            let _ = client.get(url).send().await;
+            let _ = client.get([root_url, &path].concat()).send().await;
         }
     });
 
     join_all(futures).await;
 
     let elapsed = start.elapsed();
-    println!(
-        "Sent {} requests in {:.2?} (concurrency {})",
-        num_requests, elapsed, concurrency
-    );
+    println!("Sent {num_requests} requests in {elapsed:.2?} (concurrency {concurrency})");
 }

--- a/src/bin/high_rate_attack.rs
+++ b/src/bin/high_rate_attack.rs
@@ -1,3 +1,4 @@
+use axum::http::HeaderValue;
 use futures::future::join_all;
 use neptune_explorer::path::ExplorerPath;
 use rand::rng;
@@ -20,7 +21,11 @@ async fn main() {
         let path = rng.random::<ExplorerPath>().to_string();
         let client = &client;
         async move {
-            let _ = client.get([root_url, &path].concat()).send().await;
+            let _ = client
+                .get([root_url, &path].concat())
+                .header("X-Real-IP-Override", HeaderValue::from_static("1.2.3.4"))
+                .send()
+                .await;
         }
     });
 

--- a/src/bin/scraper.rs
+++ b/src/bin/scraper.rs
@@ -52,7 +52,7 @@ async fn main() {
                         if resp.status().is_success() {
                             match resp.text().await {
                                 Ok(text) => {
-                                    info!("Success fetching {}", url);
+                                    info!("Success fetching {url}");
                                     let mut urls_guard = urls_clone.lock().unwrap();
                                     for cap in href_regex.captures_iter(&text) {
                                         let href = &cap[1];
@@ -61,16 +61,13 @@ async fn main() {
                                         {
                                             let normalized = parsed_url.as_str();
                                             if urls_guard.insert(normalized.to_owned()) {
-                                                info!(
-                                                    "Added new URL to dictionary: {}",
-                                                    normalized
-                                                );
+                                                info!("Added new URL to dictionary: {normalized}");
                                             }
                                         }
                                     }
                                 }
                                 Err(e) => {
-                                    warn!("Failed to read response body from {}: {}", url, e);
+                                    warn!("Failed to read response body from {url}: {e}");
                                 }
                             }
                         } else {
@@ -79,9 +76,9 @@ async fn main() {
                     }
                     Err(err) => {
                         if err.is_timeout() {
-                            warn!("Timeout fetching {}", url);
+                            warn!("Timeout fetching {url}");
                         } else {
-                            error!("Error fetching {}: {}", url, err);
+                            error!("Error fetching {url}: {err}");
                         }
                     }
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,5 +3,8 @@ pub mod html;
 pub mod http_util;
 pub mod model;
 pub mod neptune_rpc;
+
+#[cfg(feature = "attacks")]
+pub mod path;
 pub mod rpc;
 pub mod shared;

--- a/src/main.rs
+++ b/src/main.rs
@@ -134,7 +134,7 @@ where
         let ip = {
             // If feature flag "attacks" is disabled, or if for whatever reason
             // extracting the mock IP from the header "X-Real-IP-Override"
-            // false, fall back to the default: extracting the IP from the
+            // fails, fall back to the default: extracting the IP from the
             // socket address.
             let socket_ip = parts
                 .extensions

--- a/src/neptune_rpc.rs
+++ b/src/neptune_rpc.rs
@@ -240,7 +240,7 @@ impl AuthenticatedClient {
                         },
                     )
                 })
-                .collect::<Vec<(_, _)>>();
+                .collect();
             return Ok(Ok(addition_record_indices));
         }
 

--- a/src/path.rs
+++ b/src/path.rs
@@ -1,0 +1,96 @@
+use std::fmt;
+
+use neptune_cash::api::export::Digest;
+use neptune_cash::prelude::triton_vm::prelude::BFieldElement;
+
+#[derive(Debug, Clone)]
+pub enum ExplorerPath {
+    Block(BlockIdentifier),
+    Utxo(u64),
+    Announcement(BlockIdentifier, usize),
+    Rpc(RpcPath),
+}
+
+impl rand::distr::Distribution<ExplorerPath> for rand::distr::StandardUniform {
+    fn sample<R: rand::Rng + ?std::marker::Sized>(&self, rng: &mut R) -> ExplorerPath {
+        let _ = rng;
+        match rng.random_range(0..4) {
+            0 => ExplorerPath::Block(rng.random()),
+            1 => ExplorerPath::Utxo(rng.random()),
+            2 => ExplorerPath::Announcement(rng.random(), rng.random_range(0usize..(1 << 31))),
+            3 => ExplorerPath::Rpc(rng.random()),
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl fmt::Display for ExplorerPath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            ExplorerPath::Block(block_identifier) => format!("block/{block_identifier}"),
+            ExplorerPath::Utxo(index) => format!("utxo/{index}"),
+            ExplorerPath::Announcement(block_identifier, index) => {
+                format!("announcement/{block_identifier}/{index}")
+            }
+            ExplorerPath::Rpc(rpc_path) => format!("rpc/{rpc_path}"),
+        };
+        write!(f, "{s}")
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum BlockIdentifier {
+    Tip,
+    Genesis,
+    Height(u64),
+    Digest(Digest),
+}
+impl rand::distr::Distribution<BlockIdentifier> for rand::distr::StandardUniform {
+    fn sample<R: rand::Rng + ?std::marker::Sized>(&self, rng: &mut R) -> BlockIdentifier {
+        match rng.random_range(0..4) {
+            0 => BlockIdentifier::Tip,
+            1 => BlockIdentifier::Genesis,
+            2 => BlockIdentifier::Height(rng.random_range(0u64..BFieldElement::P)),
+            3 => BlockIdentifier::Digest(rng.random()),
+            _ => unreachable!(),
+        }
+    }
+}
+impl fmt::Display for BlockIdentifier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            BlockIdentifier::Tip => "tip".to_string(),
+            BlockIdentifier::Genesis => "genesis".to_string(),
+            BlockIdentifier::Height(height) => format!("height_or_digest/{height}"),
+            BlockIdentifier::Digest(digest) => format!("height_or_digest/{digest:x}"),
+        };
+        write!(f, "{s}")
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum RpcPath {
+    BlockInfo(BlockIdentifier),
+    BlockDigest(BlockIdentifier),
+    UtxoDigest(usize),
+}
+impl rand::distr::Distribution<RpcPath> for rand::distr::StandardUniform {
+    fn sample<R: rand::Rng + ?std::marker::Sized>(&self, rng: &mut R) -> RpcPath {
+        match rng.random_range(0..3) {
+            0 => RpcPath::BlockInfo(rng.random()),
+            1 => RpcPath::BlockDigest(rng.random()),
+            2 => RpcPath::UtxoDigest(rng.random_range(0usize..(1 << 31))),
+            _ => unreachable!(),
+        }
+    }
+}
+impl fmt::Display for RpcPath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            RpcPath::BlockInfo(block_identifier) => format!("block_info/{block_identifier}"),
+            RpcPath::BlockDigest(block_identifier) => format!("block_digest/{block_identifier}"),
+            RpcPath::UtxoDigest(index) => format!("utxo_digest/{index}"),
+        };
+        write!(f, "{s}")
+    }
+}


### PR DESCRIPTION
This PR
 - Adds a framework for simulating web-level attacks such as DoS through
   flooding and for monitoring the health of the server. The purpose of this
  framework is to quantify and test the efficacy of countermeasures against
  such attacks.
 - Adds a basic countermeasure against flooding, namely rate-limiting.

To test without rate-limiting:
 1. Open 4 terminal windows.
 2. Start neptune-core in one.
 3. Start neptune-explorer in two: `cargo run -- --site-domain test`
 4. Start the scraper in three: `cargo run --bin scraper --features="attacks"`
    and observe the green info logs indicating successful retrieval of web
    pages.
 5. Start the attack in four:
    `cargo run --bin high_rate_attack --features="attacks"`.
    Observe that in window three the green info messages turn into orange warn
    messages, indicating response timeouts. Also, try opening an explorer page.
    It gives a timeout.

To test with rate-limiting:
 3. Start neptune-explorer in two, but with feature flag "attacks" enabled:
    `cargo run --features="attacks" -- --site-domain test`. With this feature flag
    enabled, the value of HTTP header X-Real-IP-Override is used for the IP, so
    so you can simulate an attack from a different IP from the scraper.
 5. Start the attack and observe that the green info messages continue without
    interruption. Opening an explorer page does not result in a timeout.